### PR TITLE
chore(gitignore): allow .htaccess and migration files in backend/wordpress

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 #Wordpress
 /backend/wordpress/*
 !/backend/wordpress/wp-content/themes/psel-monks-theme/**
+!/backend/wordpress/.htaccess
 
 # Logs
 logs

--- a/backend/wordpress/.htaccess
+++ b/backend/wordpress/.htaccess
@@ -1,0 +1,20 @@
+# BEGIN WordPress
+# As diretrizes (linhas) entre "BEGIN WordPress" e "END WordPress" são
+# geradas dinamicamente e só devem ser modificadas através de filtros do WordPress.
+# Quaisquer alterações nas diretivas entre esses marcadores serão sobrescritas.
+php_value upload_max_filesize 528M
+php_value post_max_size 528M
+php_value memory_limit 528M
+php_value max_execution_time 300
+php_value max_input_time 300
+
+<IfModule mod_rewrite.c>
+RewriteEngine On
+RewriteRule .* - [E=HTTP_AUTHORIZATION:%{HTTP:Authorization}]
+RewriteBase /
+RewriteRule ^index\.php$ - [L]
+RewriteCond %{REQUEST_FILENAME} !-f
+RewriteCond %{REQUEST_FILENAME} !-d
+RewriteRule . /index.php [L]
+</IfModule>
+# END WordPress


### PR DESCRIPTION
- Updated .gitignore to include the .htaccess file in backend/wordpress
- Added All-in-One WP Migration export file to backend/wordpress/migrations